### PR TITLE
Added GPIO functions

### DIFF
--- a/adc.c
+++ b/adc.c
@@ -37,6 +37,7 @@ void ADC14_IRQHandler(void)
             powerStatus[2*i] = (uint8_t) ADC14->MEM[i+8] & 0xFF;               // Store lower half of conversions
             powerStatus[(2*i)+1] = (uint8_t) (ADC14->MEM[i+8] >> 8) & 0xFF;    // Store upper half of conversions
         }
+        setLEDColor((uint16_t)ADC14->MEM[13] & 0xFFFF);                        // Select color based on battery reading
         uartSendCompByte((uint8_t) 0xFE);                                      // Transmit 0xFE to denote power data
         uartSendCompN(powerStatus, 12);                                        // Transmit data to computer
     }
@@ -50,20 +51,20 @@ void adcConfiguration()
     ADC14->CTL1     |= ADC14_CTL1_RES__14BIT;                    // Set ADC to 14-bit resolution
 
     // Map channel AXX to MCTL[XX] and set channels 7 and 13 to be end of sequence bits
-    ADC14->MCTL[0]  |= ADC14_MCTLN_INCH_0;
-    ADC14->MCTL[1]  |= ADC14_MCTLN_INCH_1;
-    ADC14->MCTL[2]  |= ADC14_MCTLN_INCH_2;
-    ADC14->MCTL[3]  |= ADC14_MCTLN_INCH_3;
-    ADC14->MCTL[4]  |= ADC14_MCTLN_INCH_4;
-    ADC14->MCTL[5]  |= ADC14_MCTLN_INCH_5;
-    ADC14->MCTL[6]  |= ADC14_MCTLN_INCH_6;
-    ADC14->MCTL[7]  |= ADC14_MCTLN_INCH_7 | ADC14_MCTLN_EOS;
-    ADC14->MCTL[8]  |= ADC14_MCTLN_INCH_8;
-    ADC14->MCTL[9]  |= ADC14_MCTLN_INCH_9;
-    ADC14->MCTL[10] |= ADC14_MCTLN_INCH_10;
-    ADC14->MCTL[11] |= ADC14_MCTLN_INCH_11;
-    ADC14->MCTL[12] |= ADC14_MCTLN_INCH_12;
-    ADC14->MCTL[13] |= ADC14_MCTLN_INCH_13 | ADC14_MCTLN_EOS;
+    ADC14->MCTL[0]  |= ADC14_MCTLN_INCH_0;                       // Motor 1
+    ADC14->MCTL[1]  |= ADC14_MCTLN_INCH_1;                       // Motor 2
+    ADC14->MCTL[2]  |= ADC14_MCTLN_INCH_2;                       // Motor 3
+    ADC14->MCTL[3]  |= ADC14_MCTLN_INCH_3;                       // Motor 4
+    ADC14->MCTL[4]  |= ADC14_MCTLN_INCH_4;                       // Motor 5
+    ADC14->MCTL[5]  |= ADC14_MCTLN_INCH_5;                       // Motor 6
+    ADC14->MCTL[6]  |= ADC14_MCTLN_INCH_6;                       // Motor 7
+    ADC14->MCTL[7]  |= ADC14_MCTLN_INCH_7 | ADC14_MCTLN_EOS;     // Motor 8
+    ADC14->MCTL[8]  |= ADC14_MCTLN_INCH_8;                       // 3.3V or 5V current
+    ADC14->MCTL[9]  |= ADC14_MCTLN_INCH_9;                       // 9V current
+    ADC14->MCTL[10] |= ADC14_MCTLN_INCH_10;                      // 12V current
+    ADC14->MCTL[11] |= ADC14_MCTLN_INCH_11;                      // 19V current
+    ADC14->MCTL[12] |= ADC14_MCTLN_INCH_12;                      // 48V current
+    ADC14->MCTL[13] |= ADC14_MCTLN_INCH_13 | ADC14_MCTLN_EOS;    // Battery voltage
 
     ADC14->IER0     |= ADC14_IER0_IE7 | ADC14_IER0_IE13;         // Allow interrupts on EOS bits
     ADC14->CTL0     |= ADC14_CTL0_ENC;                           // Enable ADC Encoding

--- a/gpio.c
+++ b/gpio.c
@@ -6,3 +6,32 @@
 #include "timer.h"
 
 
+void gpioConfiguration()
+{
+    // P2.4 = Red, P2.5 = Green, P2.6 = Blue
+    P2SEL0 &= ~(BIT4 | BIT5 | BIT6);
+    P2SEL1 &= ~(BIT4 | BIT5 | BIT6);  // Set pins to gpio mode
+    P2DIR  |= BIT4 | BIT5 | BIT6;     // Set pins to outputs
+    P2OUT  &= ~(BIT4 | BIT5 | BIT6);  // Assure pins are off
+}
+
+void setLEDColor(uint16_t battV)
+{
+    // If read voltage < 2.33V, battery voltage < 14V
+    if(battV < LOW_VOLTAGE)
+    {
+        P2OUT &= ~(BIT4 | BIT5 | BIT6);  // Assure pins are off
+        P2OUT |= BIT4;                   // Turn red LED on
+    }
+    // If read voltage > 2.5V, battery voltage > 15V
+    else if(battV > HIGH_VOLTAGE)
+    {
+        P2OUT &= ~(BIT4 | BIT5 | BIT6);  // Assure pins are off
+        P2OUT |= BIT5;                   // Turn green LED on
+    }
+    else
+    {
+        P2OUT &= ~(BIT4 | BIT5 | BIT6);  // Assure pins are off
+        P2OUT |= BIT6;                   // Turn blue LED on
+    }
+}

--- a/gpio.h
+++ b/gpio.h
@@ -1,6 +1,11 @@
 #ifndef GPIO_H_
 #define GPIO_H_
 
+#define LOW_VOLTAGE    11528  // ADC reading of 2.33V = Battery voltage 14V
+#define HIGH_VOLTAGE   12410  // ADC reading of 2.5V  = Battery voltage 15V
 
+void gpioConfiguration();
+
+void setLEDColor(uint16_t battV);
 
 #endif /* GPIO_H_ */

--- a/main.c
+++ b/main.c
@@ -9,5 +9,16 @@
 
 void main(void)
 {
-	WDT_A->CTL = WDT_A_CTL_PW | WDT_A_CTL_HOLD;		// stop watchdog timer
+	WDT_A->CTL = WDT_A_CTL_PW | WDT_A_CTL_HOLD;		// Stop watchdog timer
+	adcConfiguration();
+	uartCompConfigure();
+	uartAtmelConfigure();
+	gpioConfiguration();
+	timerConfiguration();
+	startReadMotorCurrents();                       // Begin first motor ADC conversion
+
+	while(1)
+	{
+	    // Literally nothing
+	}
 }


### PR DESCRIPTION
1. gpioConfiguration - Sets up P2.4, P2.5, and P2.6 to be outputs
     which control the red, green, and blue LEDs respectively.
2. setLEDColor - Takes in the battery voltage ADC reading and sets
     the LED color based on what is read.
3. Sets the LED color in the ADC power status reading routine.